### PR TITLE
Remove X check on GetSpawnPoint

### DIFF
--- a/Helpers/PlayerHelpers/PlayerHelpers.cs
+++ b/Helpers/PlayerHelpers/PlayerHelpers.cs
@@ -53,7 +53,7 @@ namespace HamstarHelpers.PlayerHelpers {
 		public static Vector2 GetSpawnPoint( Player player ) {
 			var pos = new Vector2();
 
-			if( player.SpawnX >= 0 && player.SpawnY >= 0 ) {
+			if( player.SpawnY >= 0 ) {
 				pos.X = (float)(player.SpawnX * 16 + 8 - player.width / 2);
 				pos.Y = (float)(player.SpawnY * 16 - player.height);
 			} else {


### PR DESCRIPTION
The SpawnX >= 0 check on GetSpawnPoint will erroneously cause GetSpawnPoint to return the player's actual spawn point only if it is at world X center or to the east of center. It should return the spawn location even if east of center. It is understandable, though, why you might not want it to be underground, so I kept the SpawnY >= 0 check.